### PR TITLE
Update ZIO to 1.0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val zioVersion = "1.0.3"
+val zioVersion = "1.0.6"
 
 lazy val root = project
   .in(file("."))
@@ -7,7 +7,6 @@ lazy val root = project
     Test / test := {
       val _ = (Test / g8Test).toTask("").value
     },
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio"               % zioVersion,
       "dev.zio" %% "zio-test"          % zioVersion % Test,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("ch.epfl.lamp"              % "sbt-dotty"    % "0.5.4")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.17")

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,4 +1,4 @@
-val zioVersion = "1.0.3"
+val zioVersion = "1.0.6"
 
 lazy val root = project
   .in(file("."))
@@ -11,7 +11,6 @@ lazy val root = project
         scalaVersion := "$dotty_version$"
       )
     ),
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio"               % zioVersion,
       "dev.zio" %% "zio-test"          % zioVersion % Test,
@@ -19,6 +18,5 @@ lazy val root = project
       "dev.zio" %% "zio-test-junit"    % zioVersion % Test,
       "dev.zio" %% "zio-test-magnolia" % zioVersion % Test
     ),
-    libraryDependencies := libraryDependencies.value.map(_.withDottyCompat(scalaVersion.value)),
     testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
   )

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("ch.epfl.lamp"              % "sbt-dotty"    % "0.5.4")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.17")


### PR DESCRIPTION
- ZIO updated to 1.0.6
- removed `better-monadic-for` (Scala 3 doesn't support Scala 2 compiler plugins)
- removed `withDottyCompat` (doesn't seem to be useful and fixes problem with tests)
- removed `sbt-dotty` (not needed since sbt 1.5.0)